### PR TITLE
Update the location & location_cache logic

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -422,12 +422,11 @@ class PokemonGoBot(object):
                 logger.log('GeoPosition: {}'.format(self.position))
                 logger.log('')
                 has_position = True
-                return
             except:
                 logger.log('[x] The location given using -l could not be parsed. Checking for a cached location.')
                 pass
 
-        if self.config.location_cache and not has_position:
+        if self.config.location_cache:
             try:
                 #
                 # save location flag used to pull the last known location from
@@ -438,7 +437,7 @@ class PokemonGoBot(object):
                     location_json = json.load(f)
                     location = (location_json['lat'],
                                      location_json['lng'], 0.0)
-                    print(location)
+                    #print(location)
                     self.api.set_position(*location)
 
                     logger.log('')
@@ -452,8 +451,11 @@ class PokemonGoBot(object):
                     has_position = True
                     return
             except:
-                sys.exit(
-                    "No cached Location. Please specify initial location.")
+                if(has_position == False):
+                    sys.exit(
+                        "No cached Location. Please specify initial location.")
+                logger.log('[x] Parsing cached location failed, try to use the initial location...')
+                pass
 
     def _get_pos_by_name(self, location_name):
         # Check if the given location is already a coordinate.


### PR DESCRIPTION
Short Description: 

Fixes:
- 
- 
- 


Previously, the location_cache can't be used, even people set location_cache to TRUE. Everytime, it starts from the initial position.

Now the bot check the initial position first. 
Then check if people set location_cache. If so, read it and update it, otherwise use the initial location.
If there is no initial location and no location cache, print msg and exit.